### PR TITLE
Functions ucfirst and strtolower in javascript

### DIFF
--- a/lib/bouncehandler.js
+++ b/lib/bouncehandler.js
@@ -777,7 +777,7 @@ var BounceHandler = function() {
     }
      
     this.find_x_header = function(xheader){
-        var xheader = ucfirst(strtolower(xheader));
+        var xheader = xheader.toLowerCase().charAt(0).toUpperCase() + xheader.toLowerCase().slice(1);
         // check the header
         if(typeof this.head_hash[xheader] != 'undefined'){
             return this.head_hash[xheader];


### PR DESCRIPTION
The functions ucfirst and strtolower do not exist in javascript and were replaced with the respective functions.
